### PR TITLE
Added clarification in README for Git LFS usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,8 @@ The model can be used in these two ways.
 ### Use presented function with python
 
 To use "strabismus_predict" function give it image path as string.
+
+---
+
+### Note
+The model file `model/model.h5` is tracked by Git LFS (Large File Storage). If you're encountering issues with pulling the model file, ensure that Git LFS is installed on your system. You can find installation instructions [here](https://docs.github.com/en/repositories/working-with-files/managing-large-files/installing-git-large-file-storage).


### PR DESCRIPTION
Hi there,

I've made a quick update to the README to clarify the usage of Git LFS (Large File Storage) for tracking the model file (`model/model.h5`). This ensures that users won't have trouble downloading the model file when cloning the repository on systems without Git LFS installed.

Summary of changes:
- Added a 'Note' section explaining that the model file is tracked by Git LFS and may not be automatically downloaded on systems without Git LFS.
- Included a link to the Git LFS documentation for installation assistance.

Thank you for considering this pull request, and I'm open to any feedback you may have.

On a side note, thank you for making this project open-source. It's been helpful! I'm currently working on a project classifying different types of strabismus and am in need of a dataset. Data on this is very scarce, so if you could share the dataset used to train this project, it would be greatly appreciated. I'm ready to manually label the dataset for classifying the four different types. Please let me know if you can assist at aswinpradeepc@gmail.com.

Best regards,
Aswin Pradeep